### PR TITLE
Fix open booking UX and policy GitHub issues

### DIFF
--- a/src/Application/Command/SendReservationNotification.php
+++ b/src/Application/Command/SendReservationNotification.php
@@ -12,6 +12,10 @@ readonly class SendReservationNotification
         public string $email,
         public string $username,
         public string $paymentCode,
-        public Money $paymentAmount
+        public Money $paymentAmount,
+        public ?string $lessonTitle = null,
+        public ?\DateTimeImmutable $lessonSchedule = null,
+        public ?string $ticketType = null,
+        public ?string $childName = null,
     ) {}
 }

--- a/src/Application/CommandHandler/AddBookingHandler.php
+++ b/src/Application/CommandHandler/AddBookingHandler.php
@@ -67,6 +67,12 @@ final readonly class AddBookingHandler
                 $user->getName(),
                 $command->paymentCode,
                 $payment?->getAmount() ?? Money::zero(Currency::of('PLN')),
+                lessonTitle: $lesson->getMetadata()
+                    ->title,
+                lessonSchedule: $lesson->getMetadata()
+                    ->schedule,
+                ticketType: $ticketOption->type->value,
+                childName: $booking->getChild()?->getName(),
             ))->with(new DispatchAfterCurrentBusStamp())
         );
     }

--- a/src/Application/CommandHandler/SendReservationNotificationHandler.php
+++ b/src/Application/CommandHandler/SendReservationNotificationHandler.php
@@ -5,18 +5,31 @@ declare(strict_types=1);
 namespace App\Application\CommandHandler;
 
 use App\Application\Command\SendReservationNotification;
+use App\Application\Service\InAppNotificationService;
+use App\Entity\NotificationSeverity;
+use App\Repository\SettingRepository;
+use App\Repository\UserRepository;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\NotifierInterface;
 use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
 readonly class SendReservationNotificationHandler
 {
+    private const string DEFAULT_BLIK_PHONE = '571 531 213';
+
+    private const string DEFAULT_BANK_ACCOUNT = '46 2490 0005 0000 4000 1897 5420';
+
     public function __construct(
         private NotifierInterface $notifier,
         private TranslatorInterface $translator,
-        private Environment $twig
+        private Environment $twig,
+        private InAppNotificationService $inAppNotifications,
+        private UserRepository $userRepository,
+        private UrlGeneratorInterface $urlGenerator,
+        private SettingRepository $settingRepository,
     ) {}
 
     public function __invoke(SendReservationNotification $command): void
@@ -24,8 +37,12 @@ readonly class SendReservationNotificationHandler
         $translatorContext = [
             'paymentCode' => $command->paymentCode,
             'paymentAmount' => $command->paymentAmount,
-            'blikPhoneNumber' => '571 531 213',
-            'bankAccountNumber' => '46 2490 0005 0000 4000 1897 5420',
+            'blikPhoneNumber' => $this->paymentSetting('blik_phone', self::DEFAULT_BLIK_PHONE),
+            'bankAccountNumber' => $this->paymentSetting('bank_account', self::DEFAULT_BANK_ACCOUNT),
+            'lessonTitle' => $command->lessonTitle,
+            'lessonSchedule' => $command->lessonSchedule,
+            'ticketType' => $command->ticketType,
+            'childName' => $command->childName,
         ];
 
         $subject = $this->translator->trans('reservation.subject', [], 'emails');
@@ -37,5 +54,34 @@ readonly class SendReservationNotificationHandler
 
         $recipient = new Recipient($command->email);
         $this->notifier->send($notification, $recipient);
+
+        $user = $this->userRepository->findOneBy([
+            'email' => $command->email,
+        ]);
+        if ($user !== null) {
+            $this->inAppNotifications->notify(
+                $user,
+                $this->translator->trans('notifications.in_app.reservation.title', [], 'messages'),
+                $this->translator->trans('notifications.in_app.reservation.body', [
+                    'code' => $command->paymentCode,
+                    'amount' => (string) $command->paymentAmount->getAmount(),
+                ], 'messages'),
+                $this->urlGenerator->generate('dashboard'),
+                NotificationSeverity::Success,
+            );
+        }
+    }
+
+    private function paymentSetting(string $key, string $default): string
+    {
+        $setting = $this->settingRepository->findOneByKey('payment');
+        $content = $setting?->getContent();
+        if (! is_array($content)) {
+            return $default;
+        }
+
+        $value = $content[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : $default;
     }
 }

--- a/src/Entity/Booking.php
+++ b/src/Entity/Booking.php
@@ -376,6 +376,11 @@ class Booking
         return $this->status === self::STATUS_ACTIVE;
     }
 
+    public function occupiesSeat(): bool
+    {
+        return $this->isPending() || $this->isActive();
+    }
+
     public function isPast(): bool
     {
         return $this->status === self::STATUS_PAST;
@@ -389,6 +394,50 @@ class Booking
     public function canRequestRefund(): bool
     {
         return in_array($this->status, [self::STATUS_PENDING, self::STATUS_ACTIVE], true);
+    }
+
+    public function getReschedulePolicyFor(Lesson $lesson): TicketReschedulePolicy
+    {
+        $type = $this->isCarnet() ? TicketType::CARNET_4 : TicketType::ONE_TIME;
+        foreach ($lesson->getTicketOptions() as $option) {
+            if ($option->type === $type) {
+                return $option->reschedulePolicy;
+            }
+        }
+
+        return TicketReschedulePolicy::NOT_ALLOWED;
+    }
+
+    public function hasBeenRescheduled(): bool
+    {
+        return $this->getLessonsMap()
+            ->getRescheduled() !== [];
+    }
+
+    public function canRescheduleLesson(Lesson $lesson): bool
+    {
+        if (! $this->canBeRescheduled() || ! $lesson->cancellationAvailable()) {
+            return false;
+        }
+
+        return match ($this->getReschedulePolicyFor($lesson)) {
+            TicketReschedulePolicy::NOT_ALLOWED => false,
+            TicketReschedulePolicy::ONETIME_24H_BEFORE => ! $this->hasBeenRescheduled(),
+            TicketReschedulePolicy::UNLIMITED_24H_BEFORE => true,
+        };
+    }
+
+    public function canRequestRefundForLesson(Lesson $lesson): bool
+    {
+        return $this->canRequestRefund() && $lesson->cancellationAvailable();
+    }
+
+    public function canCancelLesson(Lesson $lesson): bool
+    {
+        return $this->occupiesSeat()
+            && $lesson->future()
+            && $this->getLessonsMap()
+                ->isActiveLesson($lesson->getId());
     }
 
     public function isCancelled(): bool
@@ -446,7 +495,9 @@ class Booking
 
     public function isCarnet(): bool
     {
-        return $this->lessons->count() > 1;
+        $summary = $this->getLessonStatusSummary();
+
+        return ($summary['total'] - count($this->getLessonsMap()->getRescheduled())) > 1;
     }
 
     public function getTotalLessons(): int

--- a/src/Entity/Booking.php
+++ b/src/Entity/Booking.php
@@ -429,7 +429,9 @@ class Booking
 
     public function canRequestRefundForLesson(Lesson $lesson): bool
     {
-        return $this->canRequestRefund() && $lesson->cancellationAvailable();
+        return $this->canRequestRefund()
+            && $lesson->cancellationAvailable()
+            && $this->hasPaidPayment();
     }
 
     public function canCancelLesson(Lesson $lesson): bool
@@ -438,6 +440,18 @@ class Booking
             && $lesson->future()
             && $this->getLessonsMap()
                 ->isActiveLesson($lesson->getId());
+    }
+
+    public function requiresNoRefundCancelWarning(Lesson $lesson): bool
+    {
+        return $this->canCancelLesson($lesson)
+            && ! $lesson->cancellationAvailable()
+            && $this->hasPaidPayment();
+    }
+
+    public function hasPaidPayment(): bool
+    {
+        return $this->payment?->getStatus() === Payment::STATUS_PAID;
     }
 
     public function isCancelled(): bool

--- a/src/Entity/Lesson.php
+++ b/src/Entity/Lesson.php
@@ -136,7 +136,7 @@ class Lesson
             0,
             $this->metadata->capacity
             - $this->bookings->filter(
-                fn(Booking $booking): bool => $booking->isActive() && $booking->getLessonsMap()
+                fn(Booking $booking): bool => $booking->occupiesSeat() && $booking->getLessonsMap()
                     ->active->hasKey($this->id)
             )
                 ->count()

--- a/src/MessageHandler/RefundLessonBookingHandler.php
+++ b/src/MessageHandler/RefundLessonBookingHandler.php
@@ -48,6 +48,27 @@ class RefundLessonBookingHandler
             return;
         }
 
+        $lesson = null;
+        foreach ($booking->getLessons() as $booked) {
+            if ($booked->getId()->equals($command->getLessonId())) {
+                $lesson = $booked;
+                break;
+            }
+        }
+
+        $isAdmin = in_array('ROLE_ADMIN', $command->getRefundedBy()->getRoles(), true);
+        if ($lesson !== null && ! $isAdmin && ! $booking->canRequestRefundForLesson($lesson)) {
+            $this->logger->warning('Refund blocked within 24h of the lesson', [
+                'bookingId' => $booking->getId()
+                    ->toRfc4122(),
+                'lessonId' => $command->getLessonId()
+                    ->toRfc4122(),
+                'refundedById' => $command->getRefundedBy()
+                    ->getId(),
+            ]);
+            throw new \RuntimeException('Refund is not available within 24h of the lesson');
+        }
+
         // Check if we can request a refund
         if (! $this->bookingStateMachine->can($booking, 'request_refund')) {
             $this->logger->error('Cannot apply refund transition to booking', [

--- a/src/MessageHandler/RescheduleLessonBookingHandler.php
+++ b/src/MessageHandler/RescheduleLessonBookingHandler.php
@@ -69,6 +69,27 @@ readonly class RescheduleLessonBookingHandler
             return;
         }
 
+        $isAdmin = in_array('ROLE_ADMIN', $command->getRescheduledBy()->getRoles(), true);
+        if (! $isAdmin && ! $booking->canRescheduleLesson($oldLesson)) {
+            $this->logger->warning('Reschedule blocked by ticket policy or 24h rule', [
+                'bookingId' => $booking->getId(),
+                'oldLessonId' => $command->getOldLessonId(),
+                'policy' => $booking->getReschedulePolicyFor($oldLesson)
+                    ->value,
+                'rescheduledById' => $command->getRescheduledBy()
+                    ->getId(),
+            ]);
+            throw new \RuntimeException('Reschedule is not allowed for this booking');
+        }
+
+        if ($newLesson->getAvailableSpots() <= 0) {
+            $this->logger->warning('Reschedule target lesson has no available spots', [
+                'bookingId' => $booking->getId(),
+                'newLessonId' => $command->getNewLessonId(),
+            ]);
+            throw new \RuntimeException('Selected lesson has no available spots');
+        }
+
         // Check workflow transition first
         if (! $this->bookingStateMachine->can($booking, 'reschedule')) {
             $this->logger->error('Cannot apply reschedule transition to booking', [

--- a/src/Repository/LessonRepository.php
+++ b/src/Repository/LessonRepository.php
@@ -205,7 +205,7 @@ class LessonRepository extends ServiceEntityRepository
         if (! $showCancelled) {
             $qb->andWhere('l.status = :status')
                 ->setParameter('status', 'active')
-                ->setParameter('bookingStatus', [Booking::STATUS_ACTIVE]);
+                ->setParameter('bookingStatus', [Booking::STATUS_PENDING, Booking::STATUS_ACTIVE]);
         } else {
             $qb->setParameter(
                 'bookingStatus',

--- a/src/UserInterface/Http/Component/AdminBookingsComponent.php
+++ b/src/UserInterface/Http/Component/AdminBookingsComponent.php
@@ -98,8 +98,8 @@ class AdminBookingsComponent extends AbstractController
 
         // Apply status filter
         if ($this->filter === 'active') {
-            $qb->andWhere('b.status = :status')
-                ->setParameter('status', Booking::STATUS_ACTIVE);
+            $qb->andWhere('b.status IN (:statuses)')
+                ->setParameter('statuses', [Booking::STATUS_PENDING, Booking::STATUS_ACTIVE]);
         } elseif ($this->filter === 'completed') {
             $qb->andWhere('b.status = :status')
                 ->setParameter('status', Booking::STATUS_PAST);
@@ -201,8 +201,8 @@ class AdminBookingsComponent extends AbstractController
                 $status = Booking::STATUS_PAST;
             }
 
-            if ($status === Booking::STATUS_ACTIVE) {
-                $result['active'] = $countValue;
+            if ($status === Booking::STATUS_ACTIVE || $status === Booking::STATUS_PENDING) {
+                $result['active'] += $countValue;
             } elseif ($status === Booking::STATUS_PAST) {
                 $result['completed'] = $countValue;
             } elseif ($status === Booking::STATUS_CANCELLED) {

--- a/src/UserInterface/Http/Component/BookingCancellationModal.php
+++ b/src/UserInterface/Http/Component/BookingCancellationModal.php
@@ -48,6 +48,9 @@ class BookingCancellationModal extends AbstractController
     #[LiveProp(writable: true)]
     public ?Ulid $selectedLessonId = null;
 
+    #[LiveProp(writable: true)]
+    public bool $lateCancelAcknowledged = false;
+
     private const array CANCELLATION_TYPES = ['reschedule', 'refund', 'cancel'];
 
     /**
@@ -64,19 +67,20 @@ class BookingCancellationModal extends AbstractController
             return [];
         }
 
-        // Get all future lessons in the same series that have available spots and no conflicts for user
         $availableLessons = $this->lessonRepository->findAvailableLessonsForReschedule(
             $series,
             $this->lesson->getMetadata()
                 ->schedule,
         );
 
-        // Remove the current lesson from the list
-        return array_filter(
+        return array_values(array_filter(
             $availableLessons,
-            fn($lesson) => $lesson->getId() !== $this->lesson->getId() && ! $this->booking->getLessons()
-                ->contains($lesson)
-        );
+            fn(Lesson $lesson): bool => ! $lesson->getId()
+                ->equals($this->lesson->getId())
+                && ! $this->booking->getLessons()
+                    ->contains($lesson)
+                && $lesson->getAvailableSpots() > 0
+        ));
     }
 
     public function getTabState(string $option): string
@@ -89,10 +93,39 @@ class BookingCancellationModal extends AbstractController
         return $this->selectedOption === $option;
     }
 
+    public function isLateCancellation(): bool
+    {
+        return $this->lesson !== null && ! $this->lesson->cancellationAvailable();
+    }
+
+    public function canShowRescheduleTab(): bool
+    {
+        return $this->canBeRescheduled();
+    }
+
+    public function canShowRefundTab(): bool
+    {
+        if (! $this->booking || ! $this->lesson) {
+            return false;
+        }
+
+        return $this->booking->canRequestRefundForLesson($this->lesson) || $this->isAdmin();
+    }
+
+    public function canShowCancelTab(): bool
+    {
+        if (! $this->booking || ! $this->lesson) {
+            return false;
+        }
+
+        return $this->booking->canCancelLesson($this->lesson) || $this->isAdmin();
+    }
+
     #[LiveAction]
     public function openModal(): void
     {
         $this->modalOpened = true;
+        $this->ensureValidSelectedOption();
     }
 
     #[LiveAction]
@@ -102,6 +135,7 @@ class BookingCancellationModal extends AbstractController
             $this->selectedOption = $option;
         }
         $this->modalOpened = true;
+        $this->ensureValidSelectedOption();
     }
 
     #[LiveAction]
@@ -124,6 +158,20 @@ class BookingCancellationModal extends AbstractController
         $securityUser = $this->getUser();
         if (! $securityUser instanceof User) {
             throw new \RuntimeException('User not authenticated or invalid user type');
+        }
+
+        if ($typeParam === 'cancel' && $this->isLateCancellation() && ! $this->lateCancelAcknowledged && ! $this->isAdmin()) {
+            throw new \RuntimeException('Late cancellation must be acknowledged');
+        }
+
+        if ($typeParam === 'reschedule' && ! $this->booking->canRescheduleLesson($this->lesson) && ! $this->isAdmin()) {
+            throw new \RuntimeException('Reschedule is not allowed for this booking');
+        }
+
+        if ($typeParam === 'refund' && ! $this->booking->canRequestRefundForLesson(
+            $this->lesson
+        ) && ! $this->isAdmin()) {
+            throw new \RuntimeException('Refund is not available within 24h of the lesson');
         }
 
         switch ($typeParam) {
@@ -162,11 +210,11 @@ class BookingCancellationModal extends AbstractController
                 break;
         }
 
-        // Reset the form
         $this->modalOpened = false;
         $this->selectedOption = 'reschedule';
         $this->cancellationReason = '';
         $this->selectedLessonId = null;
+        $this->lateCancelAcknowledged = false;
     }
 
     #[LiveAction]
@@ -181,12 +229,15 @@ class BookingCancellationModal extends AbstractController
             return false;
         }
 
-        $series = $this->lesson->getSeries();
-        $schedule = $this->lesson->getMetadata()
-            ->schedule;
+        if ($this->isAdmin()) {
+            $series = $this->lesson->getSeries();
 
-        return $series !== null
-            && $schedule > new \DateTimeImmutable()
+            return $series !== null
+                && $this->lesson->future()
+                && count($this->getAvailableLessons()) > 0;
+        }
+
+        return $this->booking->canRescheduleLesson($this->lesson)
             && count($this->getAvailableLessons()) > 0;
     }
 
@@ -196,7 +247,30 @@ class BookingCancellationModal extends AbstractController
             return $this->selectedLessonId === null;
         }
 
-        // For cancel and refund, just check if reason is provided (optional but recommended)
+        if ($this->selectedOption === 'cancel' && $this->isLateCancellation() && ! $this->isAdmin()) {
+            return ! $this->lateCancelAcknowledged;
+        }
+
         return false;
+    }
+
+    private function ensureValidSelectedOption(): void
+    {
+        if ($this->selectedOption === 'reschedule' && ! $this->canShowRescheduleTab()) {
+            $this->selectedOption = $this->canShowRefundTab() ? 'refund' : 'cancel';
+        }
+
+        if ($this->selectedOption === 'refund' && ! $this->canShowRefundTab()) {
+            $this->selectedOption = $this->canShowRescheduleTab() ? 'reschedule' : 'cancel';
+        }
+
+        if ($this->isLateCancellation() && ! $this->canShowRescheduleTab() && ! $this->canShowRefundTab()) {
+            $this->selectedOption = 'cancel';
+        }
+    }
+
+    private function isAdmin(): bool
+    {
+        return $this->isGranted('ROLE_ADMIN');
     }
 }

--- a/src/UserInterface/Http/Component/BookingCancellationModal.php
+++ b/src/UserInterface/Http/Component/BookingCancellationModal.php
@@ -98,6 +98,13 @@ class BookingCancellationModal extends AbstractController
         return $this->lesson !== null && ! $this->lesson->cancellationAvailable();
     }
 
+    public function requiresLateCancelAcknowledgment(): bool
+    {
+        return $this->booking !== null
+            && $this->lesson !== null
+            && $this->booking->requiresNoRefundCancelWarning($this->lesson);
+    }
+
     public function canShowRescheduleTab(): bool
     {
         return $this->canBeRescheduled();
@@ -106,6 +113,10 @@ class BookingCancellationModal extends AbstractController
     public function canShowRefundTab(): bool
     {
         if (! $this->booking || ! $this->lesson) {
+            return false;
+        }
+
+        if (! $this->booking->hasPaidPayment()) {
             return false;
         }
 
@@ -160,7 +171,7 @@ class BookingCancellationModal extends AbstractController
             throw new \RuntimeException('User not authenticated or invalid user type');
         }
 
-        if ($typeParam === 'cancel' && $this->isLateCancellation() && ! $this->lateCancelAcknowledged && ! $this->isAdmin()) {
+        if ($typeParam === 'cancel' && $this->requiresLateCancelAcknowledgment() && ! $this->lateCancelAcknowledged && ! $this->isAdmin()) {
             throw new \RuntimeException('Late cancellation must be acknowledged');
         }
 
@@ -247,7 +258,7 @@ class BookingCancellationModal extends AbstractController
             return $this->selectedLessonId === null;
         }
 
-        if ($this->selectedOption === 'cancel' && $this->isLateCancellation() && ! $this->isAdmin()) {
+        if ($this->selectedOption === 'cancel' && $this->requiresLateCancelAcknowledgment() && ! $this->isAdmin()) {
             return ! $this->lateCancelAcknowledged;
         }
 

--- a/src/UserInterface/Http/Component/LessonModal.php
+++ b/src/UserInterface/Http/Component/LessonModal.php
@@ -17,6 +17,9 @@ use App\Repository\PaymentCodeRepository;
 use App\Repository\PaymentRepository;
 use Brick\Money\Money;
 use Doctrine\ORM\EntityManagerInterface;
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -92,6 +95,12 @@ class LessonModal extends AbstractController
     #[LiveProp(writable: true)]
     public ?string $selectedChildId = null;
 
+    #[LiveProp(writable: true)]
+    public string $phone = '';
+
+    #[LiveProp]
+    public ?string $phoneError = null;
+
     public function __construct(
         private readonly MessageBusInterface $bus,
         private readonly ChildRepository $childRepository,
@@ -106,6 +115,8 @@ class LessonModal extends AbstractController
     public function openModal(): void
     {
         $this->modalOpened = true;
+        $this->phoneError = null;
+        $this->prefillPhone();
 
         if ($this->lesson !== null && $this->selectedTicketType === null) {
             $ticketOptions = iterator_to_array($this->lesson->getTicketOptions());
@@ -173,6 +184,8 @@ class LessonModal extends AbstractController
     public function openPaymentModal(): void
     {
         $this->paymentModal = true;
+        $this->phoneError = null;
+        $this->prefillPhone();
     }
 
     #[LiveAction]
@@ -290,6 +303,10 @@ class LessonModal extends AbstractController
                 return;
             }
 
+            if (! $this->persistPhone($user)) {
+                return;
+            }
+
             $selected = $this->lesson->getMatchingTicketOption($this->selectedTicketType);
 
             $paymentCode = new PaymentFactory()
@@ -312,6 +329,47 @@ class LessonModal extends AbstractController
             return;
         }
         $this->paymentStatus = 'error';
+    }
+
+    private function prefillPhone(): void
+    {
+        if ($this->phone !== '') {
+            return;
+        }
+
+        /** @var ?User $user */
+        $user = $this->getUser();
+        if (! $user instanceof User || $user->getPhone() === null) {
+            return;
+        }
+
+        $this->phone = PhoneNumberUtil::getInstance()->format($user->getPhone(), PhoneNumberFormat::NATIONAL);
+    }
+
+    private function persistPhone(User $user): bool
+    {
+        $this->phoneError = null;
+        $raw = trim($this->phone);
+        if ($raw === '') {
+            $this->phoneError = 'booking.phone.required';
+            return false;
+        }
+
+        try {
+            $parsed = PhoneNumberUtil::getInstance()->parse($raw, 'PL');
+            if (! PhoneNumberUtil::getInstance()->isValidNumber($parsed)) {
+                $this->phoneError = 'booking.phone.invalid';
+                return false;
+            }
+        } catch (NumberParseException) {
+            $this->phoneError = 'booking.phone.invalid';
+            return false;
+        }
+
+        $user->setPhone($parsed);
+        $this->entityManager->flush();
+
+        return true;
     }
 
     private function setPaymentAmount(Money $amount): void

--- a/src/UserInterface/Http/Component/LessonModal.php
+++ b/src/UserInterface/Http/Component/LessonModal.php
@@ -18,7 +18,6 @@ use App\Repository\PaymentRepository;
 use Brick\Money\Money;
 use Doctrine\ORM\EntityManagerInterface;
 use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -116,7 +115,6 @@ class LessonModal extends AbstractController
     {
         $this->modalOpened = true;
         $this->phoneError = null;
-        $this->prefillPhone();
 
         if ($this->lesson !== null && $this->selectedTicketType === null) {
             $ticketOptions = iterator_to_array($this->lesson->getTicketOptions());
@@ -185,7 +183,6 @@ class LessonModal extends AbstractController
     {
         $this->paymentModal = true;
         $this->phoneError = null;
-        $this->prefillPhone();
     }
 
     #[LiveAction]
@@ -303,7 +300,7 @@ class LessonModal extends AbstractController
                 return;
             }
 
-            if (! $this->persistPhone($user)) {
+            if (! $this->ensurePhoneOnAccount($user)) {
                 return;
             }
 
@@ -331,24 +328,22 @@ class LessonModal extends AbstractController
         $this->paymentStatus = 'error';
     }
 
-    private function prefillPhone(): void
+    public function needsPhone(): bool
     {
-        if ($this->phone !== '') {
-            return;
-        }
-
         /** @var ?User $user */
         $user = $this->getUser();
-        if (! $user instanceof User || $user->getPhone() === null) {
-            return;
-        }
 
-        $this->phone = PhoneNumberUtil::getInstance()->format($user->getPhone(), PhoneNumberFormat::NATIONAL);
+        return $user instanceof User && $user->getPhone() === null;
     }
 
-    private function persistPhone(User $user): bool
+    private function ensurePhoneOnAccount(User $user): bool
     {
         $this->phoneError = null;
+
+        if ($user->getPhone() !== null) {
+            return true;
+        }
+
         $raw = trim($this->phone);
         if ($raw === '') {
             $this->phoneError = 'booking.phone.required';

--- a/src/UserInterface/Http/Component/ProfileComponent.php
+++ b/src/UserInterface/Http/Component/ProfileComponent.php
@@ -37,6 +37,7 @@ class ProfileComponent extends AbstractController
     public string $email = '';
 
     #[LiveProp(writable: true)]
+    #[Assert\NotBlank(message: 'profile.phone.required')]
     public string $phone = '';
 
     #[LiveProp]
@@ -82,19 +83,20 @@ class ProfileComponent extends AbstractController
 
         $rawPhone = trim($this->phone);
         if ($rawPhone === '') {
-            $user->setPhone(null);
-        } else {
-            try {
-                $parsed = PhoneNumberUtil::getInstance()->parse($rawPhone, 'PL');
-                if (! PhoneNumberUtil::getInstance()->isValidNumber($parsed)) {
-                    $this->phoneError = 'profile.phone.invalid';
-                    return;
-                }
-                $user->setPhone($parsed);
-            } catch (NumberParseException) {
+            $this->phoneError = 'profile.phone.required';
+            return;
+        }
+
+        try {
+            $parsed = PhoneNumberUtil::getInstance()->parse($rawPhone, 'PL');
+            if (! PhoneNumberUtil::getInstance()->isValidNumber($parsed)) {
                 $this->phoneError = 'profile.phone.invalid';
                 return;
             }
+            $user->setPhone($parsed);
+        } catch (NumberParseException) {
+            $this->phoneError = 'profile.phone.invalid';
+            return;
         }
 
         $this->entityManager->flush();

--- a/src/UserInterface/Http/Component/ProfileComponent.php
+++ b/src/UserInterface/Http/Component/ProfileComponent.php
@@ -6,6 +6,9 @@ namespace App\UserInterface\Http\Component;
 
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -33,6 +36,12 @@ class ProfileComponent extends AbstractController
     #[Assert\Email(message: 'profile.email.invalid')]
     public string $email = '';
 
+    #[LiveProp(writable: true)]
+    public string $phone = '';
+
+    #[LiveProp]
+    public ?string $phoneError = null;
+
     private User $user;
 
     public function __construct(
@@ -46,6 +55,10 @@ class ProfileComponent extends AbstractController
         $user = $this->getUser();
         $this->name = $user->getName();
         $this->email = $user->getEmail();
+        $this->phone = $user->getPhone() !== null
+            ? PhoneNumberUtil::getInstance()->format($user->getPhone(), PhoneNumberFormat::NATIONAL)
+            : '';
+        $this->phoneError = null;
         $this->isEditing = true;
     }
 
@@ -53,17 +66,36 @@ class ProfileComponent extends AbstractController
     public function cancelEditing(): void
     {
         $this->isEditing = false;
+        $this->phoneError = null;
     }
 
     #[LiveAction]
     public function save(): void
     {
         $this->validate();
+        $this->phoneError = null;
 
         /** @var User $user */
         $user = $this->getUser();
         $user->setName($this->name);
         $user->setEmail($this->email);
+
+        $rawPhone = trim($this->phone);
+        if ($rawPhone === '') {
+            $user->setPhone(null);
+        } else {
+            try {
+                $parsed = PhoneNumberUtil::getInstance()->parse($rawPhone, 'PL');
+                if (! PhoneNumberUtil::getInstance()->isValidNumber($parsed)) {
+                    $this->phoneError = 'profile.phone.invalid';
+                    return;
+                }
+                $user->setPhone($parsed);
+            } catch (NumberParseException) {
+                $this->phoneError = 'profile.phone.invalid';
+                return;
+            }
+        }
 
         $this->entityManager->flush();
 
@@ -71,6 +103,17 @@ class ProfileComponent extends AbstractController
         $this->isEditing = false;
 
         $this->user = $user;
+    }
+
+    public function getFormattedPhone(): ?string
+    {
+        $phone = $this->getUser()
+            ->getPhone();
+        if ($phone === null) {
+            return null;
+        }
+
+        return PhoneNumberUtil::getInstance()->format($phone, PhoneNumberFormat::NATIONAL);
     }
 
     #[\Override]

--- a/src/UserInterface/Http/Component/SeriesEditComponent.php
+++ b/src/UserInterface/Http/Component/SeriesEditComponent.php
@@ -93,7 +93,7 @@ final class SeriesEditComponent extends AbstractController
             'amount' => '0.00',
             'currency' => 'PLN',
             'description' => '',
-            'reschedulePolicy' => TicketReschedulePolicy::UNLIMITED_24H_BEFORE->value,
+            'reschedulePolicy' => TicketReschedulePolicy::ONETIME_24H_BEFORE->value,
         ];
     }
 

--- a/src/UserInterface/Http/Component/UpcomingAttendeesComponent.php
+++ b/src/UserInterface/Http/Component/UpcomingAttendeesComponent.php
@@ -136,8 +136,8 @@ final class UpcomingAttendeesComponent extends AbstractController
         $single = [];
 
         foreach ($lesson->getBookings() as $booking) {
-            // Skip cancelled bookings if not showing them
-            if (! $booking->isActive() && ! $this->showCancelled) {
+            // Skip cancelled bookings if not showing them; pending holds a seat and must be visible
+            if (! $booking->occupiesSeat() && ! $this->showCancelled) {
                 continue;
             }
 

--- a/templates/components/BookingCancellationModal.html.twig
+++ b/templates/components/BookingCancellationModal.html.twig
@@ -260,7 +260,7 @@
                 {% if this.canShowCancelTab %}
                 <div role="tabpanel" class="space-y-4 {{ not this.isTabActive('cancel') ? 'hidden' : '' }}"
                      data-state="{{ this.getTabState('cancel') }}">
-                    {% if this.isLateCancellation %}
+                    {% if this.requiresLateCancelAcknowledgment %}
                         <div class="rounded-lg border border-workshop-red/40 bg-workshop-red/5 p-4 text-sm text-workshop-brown">
                             <p class="font-medium mb-3">{{ 'booking.late_cancel_warning'|trans }}</p>
                             <label class="flex items-start gap-2 cursor-pointer">

--- a/templates/components/BookingCancellationModal.html.twig
+++ b/templates/components/BookingCancellationModal.html.twig
@@ -89,6 +89,7 @@
             {# Tabs Navigation #}
             <div class="space-y-6">
                 <div role="tablist" class="flex items-center rounded-md bg-muted p-1 text-muted-foreground w-full">
+                    {% if this.canShowRescheduleTab %}
                     <button
                             role="tab"
                             class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
@@ -98,12 +99,11 @@
                             data-live-index-param="0"
                             data-live-option-param="reschedule"
                             aria-selected="{{ this.isTabActive('reschedule') ? 'true' : 'false' }}"
-                            {{ stimulus_controller('submit-button', {
-                                text: 'booking.reschedule'|trans
-                            }) }}
                     >
                         {{ 'booking.reschedule'|trans }}
                     </button>
+                    {% endif %}
+                    {% if this.canShowRefundTab %}
                     <button
                             role="tab"
                             class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
@@ -116,6 +116,8 @@
                     >
                         {{ 'booking.refund'|trans }}
                     </button>
+                    {% endif %}
+                    {% if this.canShowCancelTab %}
                     <button
                             role="tab"
                             class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
@@ -128,9 +130,11 @@
                     >
                         {{ 'booking.other'|trans }}
                     </button>
+                    {% endif %}
                 </div>
 
                 {# Reschedule Tab Content #}
+                {% if this.canShowRescheduleTab %}
                 <div role="tabpanel" class="space-y-4 {{ not this.isTabActive('reschedule') ? 'hidden' : '' }}"
                      data-state="{{ this.getTabState('reschedule') }}">
                     <h4 class="font-semibold">{{ 'booking.choose_alternative_workshop'|trans }}</h4>
@@ -207,8 +211,10 @@
                         </div>
                     {% endif %}
                 </div>
+                {% endif %}
 
                 {# Refund Tab Content #}
+                {% if this.canShowRefundTab %}
                 <div role="tabpanel" class="space-y-4 {{ not this.isTabActive('refund') ? 'hidden' : '' }}"
                      data-state="{{ this.getTabState('refund') }}">
                     <div class="space-y-2">
@@ -248,10 +254,21 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
 
                 {# Other Tab Content #}
+                {% if this.canShowCancelTab %}
                 <div role="tabpanel" class="space-y-4 {{ not this.isTabActive('cancel') ? 'hidden' : '' }}"
                      data-state="{{ this.getTabState('cancel') }}">
+                    {% if this.isLateCancellation %}
+                        <div class="rounded-lg border border-workshop-red/40 bg-workshop-red/5 p-4 text-sm text-workshop-brown">
+                            <p class="font-medium mb-3">{{ 'booking.late_cancel_warning'|trans }}</p>
+                            <label class="flex items-start gap-2 cursor-pointer">
+                                <input type="checkbox" data-model="lateCancelAcknowledged" class="mt-1 h-4 w-4 rounded border-input text-workshop-red">
+                                <span>{{ 'booking.late_cancel_confirm'|trans }}</span>
+                            </label>
+                        </div>
+                    {% endif %}
                     <div class="space-y-2">
                         <label for="cancellation-reason" class="block text-sm font-medium">
                             {{ 'booking.tell_us_more'|trans }}
@@ -265,14 +282,11 @@
                                     class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                                     placeholder="{{ 'booking.please_specify'|trans }}"
                             ></textarea>
-                            <p data-lov-id="src/components/CancellationDialog.tsx:224:16" data-lov-name="p"
-                               data-component-path="src/components/CancellationDialog.tsx" data-component-line="224"
-                               data-component-file="CancellationDialog.tsx" data-component-name="p"
-                               data-component-content="%7B%22text%22%3A%22An%20admin%20will%20review%20your%20request%20and%20contact%20you%20within%2024%20hours.%22%2C%22className%22%3A%22text-xs%20text-muted-foreground%20mt-2%22%7D"
-                               class="text-xs text-muted-foreground mt-2">{{ 'booking.tell_us_more_footer'|trans }}</p>
+                            <p class="text-xs text-muted-foreground mt-2">{{ 'booking.tell_us_more_footer'|trans }}</p>
                         </div>
                     </div>
                 </div>
+                {% endif %}
             </div>
 
             {# Footer Buttons #}
@@ -291,7 +305,7 @@
                         data-live-action-param="processCancellation"
                         data-live-type-param="{{ this.selectedOption }}"
                         class="inline-flex h-10 items-center justify-center rounded-md bg-workshop-red px-4 py-2 text-sm font-medium text-white ring-offset-background transition-colors hover:bg-workshop-red/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-workshop-red focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-                        {% if this.selectedOption == 'reschedule' and not this.selectedLessonId %}disabled{% endif %}
+                        {% if this.isButtonDisabled %}disabled{% endif %}
                 >
                     {% if this.selectedOption == 'reschedule' %}
                         {{ 'booking.reschedule'|trans }}

--- a/templates/components/BookingsComponent.html.twig
+++ b/templates/components/BookingsComponent.html.twig
@@ -138,7 +138,7 @@
                                 </div>
                                 <div class="p-6 flex items-center justify-center md:w-60">
                                     {% set canModify = (not isCancelled) and (not isRescheduled) and isFuture %}
-                                    {% if canModify and lesson.cancellationAvailable() %}
+                                    {% if canModify %}
                                         {{ component('BookingCancellationModal', {booking: booking, lesson: lesson}) }}
                                     {% else %}
                                         <span class="text-sm text-muted-foreground text-center">

--- a/templates/components/LessonModal.html.twig
+++ b/templates/components/LessonModal.html.twig
@@ -430,6 +430,7 @@
                             <p class="text-sm text-muted-foreground mb-4">{{ ('lesson.' ~ activeTicketOption.type.value ~ '.description')|trans|raw|nl2br }}</p>
 
                             <div class="mt-4 space-y-4">
+                                {% if this.needsPhone %}
                                 <div>
                                     <label class="text-sm font-medium leading-none block mb-1" for="booking-phone">{{ 'booking.phone.label'|trans }}</label>
                                     <input
@@ -440,10 +441,12 @@
                                         class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                                         required
                                     >
+                                    <p class="text-xs text-muted-foreground mt-1">{{ 'booking.phone.account_hint'|trans }}</p>
                                     {% if phoneError %}
                                         <p class="text-sm text-red-600 mt-1">{{ phoneError|trans }}</p>
                                     {% endif %}
                                 </div>
+                                {% endif %}
                                 <div>
                                     <label class="text-sm font-medium leading-none block mb-1">{{ 'booking.child.optional'|trans }}</label>
                                     {% set children = this.getChildren %}

--- a/templates/components/LessonModal.html.twig
+++ b/templates/components/LessonModal.html.twig
@@ -429,22 +429,39 @@
                             </div>
                             <p class="text-sm text-muted-foreground mb-4">{{ ('lesson.' ~ activeTicketOption.type.value ~ '.description')|trans|raw|nl2br }}</p>
 
-                            <div class="mt-4">
-                                <label class="text-sm font-medium leading-none block mb-1">{{ 'booking.child.label'|trans({'default':'Child (optional)'}) }}</label>
-                                {% set children = this.getChildren %}
-                                {% if children is not empty %}
-                                    <select data-model="selectedChildId" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
-                                        {% for c in children %}
-                                            <option value="{{ c.id }}" {% if selectedChildId == c.id or (selectedChildId is null and loop.first) %}selected{% endif %}>{{ c.name }}{% if c.birthday %} ({{ c.birthday }}){% endif %}</option>
-                                        {% endfor %}
-                                        <option value="">{{ 'booking.child.none'|trans({'default':'No child'}) }}</option>
-                                    </select>
-                                {% else %}
-                                    <div class="text-sm text-muted-foreground">
-                                        {{ 'booking.child.no_children'|trans({'default':'You have no children added in your profile.'}) }}
-                                        <a href="{{ path('profile') }}" class="text-workshop-red hover:underline">{{ 'booking.child.add_now'|trans({'default':'Add now'}) }}</a>
-                                    </div>
-                                {% endif %}
+                            <div class="mt-4 space-y-4">
+                                <div>
+                                    <label class="text-sm font-medium leading-none block mb-1" for="booking-phone">{{ 'booking.phone.label'|trans }}</label>
+                                    <input
+                                        id="booking-phone"
+                                        type="tel"
+                                        data-model="phone"
+                                        placeholder="{{ 'booking.phone.placeholder'|trans }}"
+                                        class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                        required
+                                    >
+                                    {% if phoneError %}
+                                        <p class="text-sm text-red-600 mt-1">{{ phoneError|trans }}</p>
+                                    {% endif %}
+                                </div>
+                                <div>
+                                    <label class="text-sm font-medium leading-none block mb-1">{{ 'booking.child.optional'|trans }}</label>
+                                    {% set children = this.getChildren %}
+                                    {% if children is not empty %}
+                                        <select data-model="selectedChildId" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
+                                            {% for c in children %}
+                                                <option value="{{ c.id }}" {% if selectedChildId == c.id or (selectedChildId is null and loop.first) %}selected{% endif %}>{{ c.name }}{% if c.birthday %} ({{ c.birthday }}){% endif %}</option>
+                                            {% endfor %}
+                                            <option value="">{{ 'booking.child.none'|trans }}</option>
+                                        </select>
+                                    {% else %}
+                                        <div class="rounded-md border border-dashed border-workshop-yellow/60 bg-workshop-yellow/10 px-3 py-3 text-sm text-workshop-brown">
+                                            <p class="font-medium mb-1">{{ 'booking.child.empty_title'|trans }}</p>
+                                            <p class="text-muted-foreground mb-2">{{ 'booking.child.empty_hint'|trans }}</p>
+                                            <a href="{{ path('profile') }}" class="text-workshop-red hover:underline font-medium">{{ 'booking.child.add_now'|trans }}</a>
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/templates/components/ProfileComponent.html.twig
+++ b/templates/components/ProfileComponent.html.twig
@@ -37,6 +37,12 @@
                                     <p class="text-lg">{{ this.user.email }}</p>
                                 </div>
                             </div>
+                            <div class="space-y-2">
+                                <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="phone">
+                                    {{ 'profile.phone'|trans }}
+                                </label>
+                                <p class="text-lg font-medium">{{ this.formattedPhone ?? ('profile.phone.empty'|trans) }}</p>
+                            </div>
                             {% if is_granted('ROLE_ADMIN') %}
                             <div class="space-y-2">
                                 <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
@@ -74,6 +80,13 @@
                                 <input type="email" data-model="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" id="email">
                                 {% if this.getErrors('email') %}
                                     <p class="text-sm text-red-600">{{ this.getErrors('email')|map(error => error|trans)|join(', ') }}</p>
+                                {% endif %}
+                            </div>
+                            <div class="space-y-2">
+                                <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="phone">{{ 'profile.phone'|trans }}</label>
+                                <input type="tel" data-model="phone" placeholder="{{ 'profile.phone.placeholder'|trans }}" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" id="phone">
+                                {% if phoneError %}
+                                    <p class="text-sm text-red-600">{{ phoneError|trans }}</p>
                                 {% endif %}
                             </div>
                             <div class="flex gap-3 pt-4 border-t">

--- a/templates/components/ProfileComponent.html.twig
+++ b/templates/components/ProfileComponent.html.twig
@@ -84,7 +84,10 @@
                             </div>
                             <div class="space-y-2">
                                 <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="phone">{{ 'profile.phone'|trans }}</label>
-                                <input type="tel" data-model="phone" placeholder="{{ 'profile.phone.placeholder'|trans }}" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" id="phone">
+                                <input type="tel" data-model="phone" required placeholder="{{ 'profile.phone.placeholder'|trans }}" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" id="phone">
+                                {% if this.getErrors('phone') %}
+                                    <p class="text-sm text-red-600">{{ this.getErrors('phone')|map(error => error|trans)|join(', ') }}</p>
+                                {% endif %}
                                 {% if phoneError %}
                                     <p class="text-sm text-red-600">{{ phoneError|trans }}</p>
                                 {% endif %}

--- a/templates/components/UpcomingAttendeesComponent.html.twig
+++ b/templates/components/UpcomingAttendeesComponent.html.twig
@@ -157,8 +157,14 @@
                                             {% endif %}
                                         </div>
                                         <div class="flex items-center gap-2">
-                                            <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors {{ booking.payment and booking.payment.status == 'paid' ? 'border-transparent bg-primary text-primary-foreground' : 'border-transparent bg-secondary text-secondary-foreground' }}">
-                                                {{ booking.payment and booking.payment.status == 'paid' ? 'admin.badges.paid'|trans : 'admin.badges.unpaid'|trans }}
+                                            <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors {{ booking.isPending ? 'border-transparent bg-amber-100 text-amber-900' : (booking.payment and booking.payment.status == 'paid' ? 'border-transparent bg-primary text-primary-foreground' : 'border-transparent bg-secondary text-secondary-foreground') }}">
+                                                {% if booking.isPending %}
+                                                    {{ 'admin.badges.pending'|trans }}
+                                                {% elseif booking.payment and booking.payment.status == 'paid' %}
+                                                    {{ 'admin.badges.paid'|trans }}
+                                                {% else %}
+                                                    {{ 'admin.badges.unpaid'|trans }}
+                                                {% endif %}
                                             </span>
                                             {% set bId = booking.id %}
                                             <div class="relative">
@@ -231,8 +237,14 @@
                                             {% endif %}
                                         </div>
                                         <div class="flex items-center gap-2">
-                                            <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors {{ booking.payment and booking.payment.status == 'paid' ? 'border-transparent bg-primary text-primary-foreground' : 'border-transparent bg-secondary text-secondary-foreground' }}">
-                                                {{ booking.payment and booking.payment.status == 'paid' ? 'admin.badges.paid'|trans : 'admin.badges.unpaid'|trans }}
+                                            <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors {{ booking.isPending ? 'border-transparent bg-amber-100 text-amber-900' : (booking.payment and booking.payment.status == 'paid' ? 'border-transparent bg-primary text-primary-foreground' : 'border-transparent bg-secondary text-secondary-foreground') }}">
+                                                {% if booking.isPending %}
+                                                    {{ 'admin.badges.pending'|trans }}
+                                                {% elseif booking.payment and booking.payment.status == 'paid' %}
+                                                    {{ 'admin.badges.paid'|trans }}
+                                                {% else %}
+                                                    {{ 'admin.badges.unpaid'|trans }}
+                                                {% endif %}
                                             </span>
                                             {% set bId = booking.id %}
                                             <div class="relative">

--- a/templates/email/reservation.html.twig
+++ b/templates/email/reservation.html.twig
@@ -1,6 +1,28 @@
 {% trans_default_domain 'emails' %}
 
 <div style="background-color: white; border: 1px solid #e5e7eb; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); padding: 2rem; max-width: 32rem; text-align: center;">
+    {% if lessonTitle %}
+        <div style="font-size: 1.125rem; font-weight: 600; color: #4c2e11; margin-bottom: 0.5rem;">
+            {{ lessonTitle }}
+        </div>
+    {% endif %}
+    {% if lessonSchedule %}
+        <div style="color: #6b7280; font-size: 0.875rem; margin-bottom: 0.25rem;">
+            {{ lessonSchedule|date('d.m.Y H:i') }}
+        </div>
+    {% endif %}
+    {% if ticketType %}
+        <div style="color: #6b7280; font-size: 0.875rem; margin-bottom: 0.25rem;">
+            {{ ('lesson.' ~ ticketType)|trans({}, 'messages') }}
+        </div>
+    {% endif %}
+    {% if childName %}
+        <div style="color: #6b7280; font-size: 0.875rem; margin-bottom: 1rem;">
+            {{ 'reservation.child'|trans({'childName': childName}) }}
+        </div>
+    {% else %}
+        <div style="margin-bottom: 1rem;"></div>
+    {% endif %}
     <div style="font-size: 1.5rem; font-weight: bold; color: #4c2e11; margin-bottom: 1rem;">
         {{ 'reservation.blik_transfer'|trans({'blikPhoneNumber': blikPhoneNumber})|raw }}
     </div>

--- a/tests/Application/CommandHandler/SendReservationNotificationHandlerTest.php
+++ b/tests/Application/CommandHandler/SendReservationNotificationHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\CommandHandler;
 
+use App\Entity\Notification;
 use PHPUnit\Framework\Attributes\Group;
 use App\Application\Command\SendReservationNotification;
 use App\Tests\Assembler\BookingAssembler;
@@ -25,6 +26,10 @@ class SendReservationNotificationHandlerTest extends KernelTestCase
         self::bootKernel();
 
         $user = UserAssembler::new()->assemble();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        $em->persist($user);
+        $em->flush();
+
         BookingAssembler::new()
             ->withPayment(
                 $payment = PaymentAssembler::new()
@@ -74,5 +79,13 @@ class SendReservationNotificationHandlerTest extends KernelTestCase
             '46 2490 0005 0000 4000 1897 5420',
             (string) ($firstEmail->getHtmlBody() ?? $firstEmail->getTextBody())
         );
+
+        $inApp = $em->getRepository(Notification::class)->findBy([
+            'user' => $user,
+        ]);
+        self::assertCount(1, $inApp);
+        self::assertSame('Rezerwacja utworzona', $inApp[0]->getTitle());
+        self::assertStringContainsString('<strong>TEST123</strong>', (string) $inApp[0]->getBody());
+        self::assertNotNull($inApp[0]->getUrl());
     }
 }

--- a/tests/Assembler/LessonAssembler.php
+++ b/tests/Assembler/LessonAssembler.php
@@ -132,7 +132,7 @@ class LessonAssembler extends EntityAssembler
                 TicketType::ONE_TIME,
                 Money::of(50, 'PLN'),
                 'Bilet jednorazowy',
-                TicketReschedulePolicy::UNLIMITED_24H_BEFORE
+                TicketReschedulePolicy::ONETIME_24H_BEFORE
             )]);
         }
 

--- a/tests/Entity/BookingReschedulePolicyTest.php
+++ b/tests/Entity/BookingReschedulePolicyTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Booking;
+use App\Entity\Payment;
 use App\Entity\TicketOption;
 use App\Entity\TicketReschedulePolicy;
 use App\Entity\TicketType;
 use App\Tests\Assembler\BookingAssembler;
 use App\Tests\Assembler\LessonAssembler;
+use App\Tests\Assembler\PaymentAssembler;
 use App\Tests\Assembler\UserAssembler;
 use Brick\Money\Money;
 use PHPUnit\Framework\Attributes\Group;
@@ -43,6 +45,7 @@ final class BookingReschedulePolicyTest extends TestCase
             ->withUser(UserAssembler::new()->assemble())
             ->withLessons($lesson)
             ->withStatus(Booking::STATUS_ACTIVE)
+            ->withPayment(PaymentAssembler::new() ->withStatus(Payment::STATUS_PAID) ->assemble())
             ->assemble();
 
         self::assertTrue($booking->canRescheduleLesson($lesson));
@@ -119,10 +122,31 @@ final class BookingReschedulePolicyTest extends TestCase
         $booking = BookingAssembler::new()
             ->withLessons($lesson)
             ->withStatus(Booking::STATUS_ACTIVE)
+            ->withPayment(PaymentAssembler::new() ->withStatus(Payment::STATUS_PAID) ->assemble())
             ->assemble();
 
         self::assertTrue($booking->canCancelLesson($lesson));
         self::assertFalse($booking->canRequestRefundForLesson($lesson));
         self::assertFalse($booking->canRescheduleLesson($lesson));
+        self::assertTrue($booking->requiresNoRefundCancelWarning($lesson));
+    }
+
+    #[Test]
+    public function unpaidLateCancelDoesNotRequireNoRefundWarning(): void
+    {
+        self::mockTime('2026-07-10 09:00:00');
+
+        $lesson = LessonAssembler::new()
+            ->withSchedule(new \DateTimeImmutable('2026-07-10 18:00:00'))
+            ->assemble();
+
+        $booking = BookingAssembler::new()
+            ->withLessons($lesson)
+            ->withStatus(Booking::STATUS_PENDING)
+            ->assemble();
+
+        self::assertTrue($booking->canCancelLesson($lesson));
+        self::assertFalse($booking->requiresNoRefundCancelWarning($lesson));
+        self::assertFalse($booking->canRequestRefundForLesson($lesson));
     }
 }

--- a/tests/Entity/BookingReschedulePolicyTest.php
+++ b/tests/Entity/BookingReschedulePolicyTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Booking;
+use App\Entity\TicketOption;
+use App\Entity\TicketReschedulePolicy;
+use App\Entity\TicketType;
+use App\Tests\Assembler\BookingAssembler;
+use App\Tests\Assembler\LessonAssembler;
+use App\Tests\Assembler\UserAssembler;
+use Brick\Money\Money;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\Test\ClockSensitiveTrait;
+
+#[Group('unit')]
+final class BookingReschedulePolicyTest extends TestCase
+{
+    use ClockSensitiveTrait;
+
+    #[Test]
+    public function oneTimePolicyAllowsSingleRescheduleBefore24h(): void
+    {
+        self::mockTime('2026-07-01 10:00:00');
+
+        $lesson = LessonAssembler::new()
+            ->withSchedule(new \DateTimeImmutable('2026-07-10 10:00:00'))
+            ->withTicketOptions([
+                new TicketOption(
+                    TicketType::ONE_TIME,
+                    Money::of(60, 'PLN'),
+                    'One time',
+                    TicketReschedulePolicy::ONETIME_24H_BEFORE,
+                ),
+            ])
+            ->assemble();
+
+        $booking = BookingAssembler::new()
+            ->withUser(UserAssembler::new()->assemble())
+            ->withLessons($lesson)
+            ->withStatus(Booking::STATUS_ACTIVE)
+            ->assemble();
+
+        self::assertTrue($booking->canRescheduleLesson($lesson));
+        self::assertTrue($booking->canRequestRefundForLesson($lesson));
+    }
+
+    #[Test]
+    public function oneTimePolicyBlocksSecondReschedule(): void
+    {
+        self::mockTime('2026-07-01 10:00:00');
+
+        $from = LessonAssembler::new()
+            ->withSchedule(new \DateTimeImmutable('2026-07-10 10:00:00'))
+            ->withTicketOptions([
+                new TicketOption(
+                    TicketType::ONE_TIME,
+                    Money::of(60, 'PLN'),
+                    'One time',
+                    TicketReschedulePolicy::ONETIME_24H_BEFORE,
+                ),
+            ])
+            ->assemble();
+        $to = LessonAssembler::new()
+            ->withSchedule(new \DateTimeImmutable('2026-07-17 10:00:00'))
+            ->assemble();
+        $user = UserAssembler::new()->withId(1)->assemble();
+
+        $booking = BookingAssembler::new()
+            ->withUser($user)
+            ->withLessons($from)
+            ->withStatus(Booking::STATUS_ACTIVE)
+            ->assemble();
+
+        $booking->rescheduleLesson($from, $to, $user);
+
+        self::assertTrue($booking->hasBeenRescheduled());
+        self::assertFalse($booking->canRescheduleLesson($to));
+    }
+
+    #[Test]
+    public function notAllowedPolicyBlocksReschedule(): void
+    {
+        self::mockTime('2026-07-01 10:00:00');
+
+        $lesson = LessonAssembler::new()
+            ->withSchedule(new \DateTimeImmutable('2026-07-10 10:00:00'))
+            ->withTicketOptions([
+                new TicketOption(
+                    TicketType::ONE_TIME,
+                    Money::of(60, 'PLN'),
+                    'One time',
+                    TicketReschedulePolicy::NOT_ALLOWED,
+                ),
+            ])
+            ->assemble();
+
+        $booking = BookingAssembler::new()
+            ->withLessons($lesson)
+            ->withStatus(Booking::STATUS_ACTIVE)
+            ->assemble();
+
+        self::assertFalse($booking->canRescheduleLesson($lesson));
+    }
+
+    #[Test]
+    public function lateCancelAllowsCancelButNotRefund(): void
+    {
+        self::mockTime('2026-07-10 09:00:00');
+
+        $lesson = LessonAssembler::new()
+            ->withSchedule(new \DateTimeImmutable('2026-07-10 18:00:00'))
+            ->assemble();
+
+        $booking = BookingAssembler::new()
+            ->withLessons($lesson)
+            ->withStatus(Booking::STATUS_ACTIVE)
+            ->assemble();
+
+        self::assertTrue($booking->canCancelLesson($lesson));
+        self::assertFalse($booking->canRequestRefundForLesson($lesson));
+        self::assertFalse($booking->canRescheduleLesson($lesson));
+    }
+}

--- a/tests/Entity/LessonAvailableSpotsTest.php
+++ b/tests/Entity/LessonAvailableSpotsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Booking;
+use App\Tests\Assembler\BookingAssembler;
+use App\Tests\Assembler\LessonAssembler;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+final class LessonAvailableSpotsTest extends TestCase
+{
+    #[Test]
+    public function pendingBookingsReduceAvailableSpots(): void
+    {
+        $lesson = LessonAssembler::new()
+            ->withCapacity(2)
+            ->assemble();
+
+        $pending = BookingAssembler::new()
+            ->withLessons($lesson)
+            ->withStatus(Booking::STATUS_PENDING)
+            ->assemble();
+        $lesson->addBooking($pending);
+
+        self::assertSame(1, $lesson->getAvailableSpots());
+        self::assertTrue($pending->occupiesSeat());
+    }
+
+    #[Test]
+    public function cancelledBookingsDoNotOccupySeats(): void
+    {
+        $lesson = LessonAssembler::new()
+            ->withCapacity(2)
+            ->assemble();
+
+        $cancelled = BookingAssembler::new()
+            ->withLessons($lesson)
+            ->withStatus(Booking::STATUS_CANCELLED)
+            ->assemble();
+        $lesson->addBooking($cancelled);
+
+        self::assertSame(2, $lesson->getAvailableSpots());
+        self::assertFalse($cancelled->occupiesSeat());
+    }
+}

--- a/tests/UserInterface/Http/Component/ProfileComponentTest.php
+++ b/tests/UserInterface/Http/Component/ProfileComponentTest.php
@@ -75,10 +75,11 @@ class ProfileComponentTest extends WebTestCase
             (string) $testComponent->render()
         );
 
-        // Set new values
+        // Set new values (phone is required on profile save)
         $testComponent
             ->set('name', 'New Name')
-            ->set('email', 'new.email@example.com');
+            ->set('email', 'new.email@example.com')
+            ->set('phone', '500 600 700');
 
         // Save changes
         $testComponent->call('save');
@@ -93,10 +94,12 @@ class ProfileComponentTest extends WebTestCase
 
         $this->assertSame('New Name', $updatedUser->getName());
         $this->assertSame('new.email@example.com', $updatedUser->getEmail());
+        $this->assertNotNull($updatedUser->getPhone());
 
         // Check if the view is updated
         $rendered = (string) $testComponent->render();
         $this->assertStringContainsString('New Name', $rendered);
         $this->assertStringContainsString('new.email@example.com', $rendered);
+        $this->assertStringContainsString('500 600 700', $rendered);
     }
 }

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -33,7 +33,8 @@ booking:
   phone:
     label: Phone number
     placeholder: e.g. 500 600 700
-    required: Phone number is required when purchasing a ticket.
+    required: Enter a phone number to complete the order.
+    account_hint: The number will be saved to your account.
     invalid: Enter a valid phone number.
   cancel_confirmation: Are you sure you want to cancel this booking?
   late_cancel_warning: 'The lesson starts in less than 24 hours. You can still cancel, but there will be no refund.'
@@ -92,6 +93,7 @@ profile:
   phone: Phone number
   phone.empty: Not provided
   phone.placeholder: e.g. 500 600 700
+  phone.required: Phone number is required.
   phone.invalid: Enter a valid phone number.
 
 payment:

--- a/translations/messages+intl-icu.pl.yaml
+++ b/translations/messages+intl-icu.pl.yaml
@@ -348,6 +348,7 @@ profile:
   phone: Numer telefonu
   phone.empty: Nie podano
   phone.placeholder: np. 500 600 700
+  phone.required: Numer telefonu jest wymagany.
   phone.invalid: Wprowadź poprawny numer telefonu.
   edit_profile: Edytuj profil
   account_actions: Akcje dostępne na koncie
@@ -378,7 +379,8 @@ booking:
   phone:
     label: 'Numer telefonu'
     placeholder: 'np. 500 600 700'
-    required: 'Numer telefonu jest wymagany przy zakupie biletu.'
+    required: 'Podaj numer telefonu, aby dokończyć zamówienie.'
+    account_hint: 'Numer zostanie zapisany na Twoim koncie.'
     invalid: 'Wprowadź poprawny numer telefonu.'
   reason_refund_description: 'Otrzymasz zwrot środków zgodnie z naszą polityką zwrotów'
   no_available_lessons: 'Brak dostępnych terminów do przełożenia'


### PR DESCRIPTION
## Summary
- Require phone at ticket purchase and expose it on the profile; polish optional child empty-state UX
- Enrich reservation email with lesson/ticket/child details; enforce one-time reschedule policy and late-cancel (no refund) confirmation
- Show pending transfer bookings in admin attendees, count them toward capacity, and include them in the admin active filter

Fixes #230
Fixes #238
Fixes #239
Fixes #240
Fixes #241
Fixes #242
Fixes #248

## Test plan
- [ ] Purchase a ticket without a phone → blocked; with phone → saved on user and shown in profile
- [ ] Reservation email includes lesson title/date, ticket type, and child name when set
- [ ] One-time ticket: reschedule once ≥24h before; second reschedule blocked; carnet unlimited still works
- [ ] Within 24h of lesson: cancel allowed only after no-refund acknowledgment; refund/reschedule hidden
- [ ] Create unpaid booking → appears immediately in admin attendees with pending badge and reduces available spots
- [ ] `docker compose run --rm php composer qa`
